### PR TITLE
Fix launchfile for s1

### DIFF
--- a/launch/sllidar_s1_launch.py
+++ b/launch/sllidar_s1_launch.py
@@ -58,7 +58,7 @@ def generate_launch_description():
                          'serial_baudrate': serial_baudrate, 
                          'frame_id': frame_id,
                          'inverted': inverted, 
-                         'angle_compensate': angle_compensate],
+                         'angle_compensate': angle_compensate}],
             output='screen'),
     ])
 


### PR DESCRIPTION
sllidar_s1_launch.py had an error:

closing parenthesis ']' does not match opening parenthesis '{' on line 56 (sllidar_s1_launch.py, line 61)