### PR TITLE
Update sllidar_s2_launch.py

### DIFF
--- a/launch/sllidar_s2_launch.py
+++ b/launch/sllidar_s2_launch.py
@@ -11,6 +11,7 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
+    channel_type =  LaunchConfiguration('channel_type', default='serial')
     serial_port = LaunchConfiguration('serial_port', default='/dev/ttyUSB0')
     serial_baudrate = LaunchConfiguration('serial_baudrate', default='1000000') #for s2 is 1000000
     frame_id = LaunchConfiguration('frame_id', default='laser')


### PR DESCRIPTION
channel_type specification missing from s2 launch file.