### PR TITLE
Fix s2 and s3 launch files

### DIFF
--- a/launch/sllidar_s2_launch.py
+++ b/launch/sllidar_s2_launch.py
@@ -11,6 +11,7 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
+    channel_type =  LaunchConfiguration('channel_type', default='serial')
     serial_port = LaunchConfiguration('serial_port', default='/dev/ttyUSB0')
     serial_baudrate = LaunchConfiguration('serial_baudrate', default='1000000') #for s2 is 1000000
     frame_id = LaunchConfiguration('frame_id', default='laser')

--- a/launch/sllidar_s3_launch.py
+++ b/launch/sllidar_s3_launch.py
@@ -11,6 +11,7 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
+    channel_type =  LaunchConfiguration('channel_type', default='serial')
     serial_port = LaunchConfiguration('serial_port', default='/dev/ttyUSB0')
     serial_baudrate = LaunchConfiguration('serial_baudrate', default='1000000')
     frame_id = LaunchConfiguration('frame_id', default='laser')


### PR DESCRIPTION
The S2 and S3 launch files (ones without the RViz) did not work. `channel_type` type was missing. I checked it on hardware and S3 launched. I believe it will also solve the issue with S2.