### PR TITLE
Revert previous bugfix on range_min

### DIFF
--- a/src/sllidar_node.cpp
+++ b/src/sllidar_node.cpp
@@ -225,7 +225,7 @@ class SLlidarNode : public rclcpp::Node
 
         scan_msg->scan_time = scan_time;
         scan_msg->time_increment = scan_time / (double)(node_count-1);
-        scan_msg->range_min = 5;
+        scan_msg->range_min = 0.15;
         scan_msg->range_max = max_distance;//8.0;
 
         scan_msg->intensities.resize(node_count);


### PR DESCRIPTION
Per LaserScan msg definition,

  float32 range_min        # minimum range value [m]
  float32 range_max        # maximum range value [m]
  float32[] ranges         # range data [m] (Note: values < range_min
    or > range_max should be discarded)

So range_min can not be that large, 5m, otherwise most useful scan data will be discarded. Revert to previous 0.15m.