### PR TITLE
Changed default scan mode in A1 launch files to allow default launch …

### DIFF
--- a/launch/sllidar_a1_launch.py
+++ b/launch/sllidar_a1_launch.py
@@ -17,7 +17,7 @@ def generate_launch_description():
     frame_id = LaunchConfiguration('frame_id', default='laser')
     inverted = LaunchConfiguration('inverted', default='false')
     angle_compensate = LaunchConfiguration('angle_compensate', default='true')
-    scan_mode = LaunchConfiguration('scan_mode', default='Sensitivity')
+    scan_mode = LaunchConfiguration('scan_mode', default='Standard')
     
     return LaunchDescription([
 

--- a/launch/view_sllidar_a1_launch.py
+++ b/launch/view_sllidar_a1_launch.py
@@ -17,7 +17,7 @@ def generate_launch_description():
     frame_id = LaunchConfiguration('frame_id', default='laser')
     inverted = LaunchConfiguration('inverted', default='false')
     angle_compensate = LaunchConfiguration('angle_compensate', default='true')
-    scan_mode = LaunchConfiguration('scan_mode', default='Sensitivity')
+    scan_mode = LaunchConfiguration('scan_mode', default='Standard')
 
     rviz_config_dir = os.path.join(
             get_package_share_directory('sllidar_ros2'),


### PR DESCRIPTION
…to work

The current default param for the A1 launch files, defaults scan_mode to 'Sensitivity'. This scan mode does not work on the older A1 lidar units. Unfortunately when it fails it still keeps the ros2 node running but data is not published from the A1. To correct this behaviour, the launch and view files for the A1 lidar are updated to default to scan_mode 'Standard' which has been to tested to work successfully.