### PR TITLE
fix: move nullptr_t definition to sdk_common.h

### DIFF
--- a/sdk/src/sdkcommon.h
+++ b/sdk/src/sdkcommon.h
@@ -33,7 +33,6 @@
  */
 
 #if defined(_WIN32)
-
 #include "arch/win32/arch_win32.h"
 #elif defined(_MACOS)
 #include "arch/macOS/arch_macOS.h"
@@ -42,6 +41,13 @@
 #else
 #error "unsupported target"
 #endif
+
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#ifndef _GXX_NULLPTR_T
+#define _GXX_NULLPTR_T
+typedef decltype(nullptr) nullptr_t;
+#endif
+#endif /* C++11.  */
 
 #include "hal/types.h"
 #include "hal/assert.h"

--- a/sdk/src/sl_lidar_driver.cpp
+++ b/sdk/src/sl_lidar_driver.cpp
@@ -59,13 +59,6 @@
 #undef max
 #endif
 
-#if defined(__cplusplus) && __cplusplus >= 201103L
-#ifndef _GXX_NULLPTR_T
-#define _GXX_NULLPTR_T
-typedef decltype(nullptr) nullptr_t;
-#endif
-#endif /* C++11.  */
-
 namespace sl {
     static void printDeprecationWarn(const char* fn, const char* replacement)
     {


### PR DESCRIPTION
Move definition of `nullptr_t` to `sdk_common.h` (it was previously located in `sl_lidar_driver.cpp`) to sdkcommon.h so sl_async_transceiver.cpp can also access it.

Before applying this change, compile will end with error because `nullptr_t` is not defined at [sdk/src/sl_async_transceiver.cpp:204](https://github.com/Slamtec/sllidar_ros2/blob/34300099fadfc772965962dec837bf436706188f/sdk/src/sl_async_transceiver.cpp#L204).

This change has been tested with gcc version 13.2.0 (Ubuntu 13.2.0-23ubuntu4)
